### PR TITLE
Migrate to Python 3

### DIFF
--- a/SpearmintClient/__init__.py
+++ b/SpearmintClient/__init__.py
@@ -1,1 +1,1 @@
-from experiment import Experiment
+from .experiment import Experiment

--- a/SpearmintClient/experiment.py
+++ b/SpearmintClient/experiment.py
@@ -23,7 +23,7 @@ class Experiment:
         api_params = {'name': name}
         r = self.call_api('find_experiment', method='get', params=api_params)
         if (r['result']): # found experiment
-            print 'resuming experiment ' + name + '...'
+            print('resuming experiment ' + name + '...')
         else:
             api_params['parameters'] = parameters
             api_params['outcome'] = outcome
@@ -31,7 +31,7 @@ class Experiment:
             if 'error' in r:
                 raise RuntimeError('failed to create experiment ' + name + '. error: ' + r['error'])
             else:
-                print 'experiment ' + name + ' was created.'
+                print('experiment ' + name + ' was created.')
         self.username = r['username']
         if run_mode.upper() == 'LOCAL':
             #Get Spearmint MongoDB credentials from Server

--- a/tune_branin_example.py
+++ b/tune_branin_example.py
@@ -9,7 +9,7 @@ def branin(x, y):
 
     result = float(result)
 
-    print 'Result = %f' % result
+    print('Result = %f' % result)
     #time.sleep(np.random.randint(60))
     return result
 


### PR DESCRIPTION
Straightforward migration using 2to3 without any manual change. The migration was tested with corresponding conversion of Spearmint repository.